### PR TITLE
Remove unncessary snippet wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^1.1.3",
+    "common-tags": "^1.4.0",
     "data.either": "^1.5.0",
     "data.maybe": "^1.2.2",
     "data.task": "^3.1.1",

--- a/reporter.js
+++ b/reporter.js
@@ -34,7 +34,7 @@ const listOutput = (results, file) => {
     .forEach(c => {
 
       console.log(chalk.white(`// --- Snippet #${c.id} in ${chalk.bold(file)} ---`))
-      c.stdout.forEach(o => console.log(chalk.white(o)))
+      console.log(chalk.white(c.stdout))
       console.log()
     })
 
@@ -49,7 +49,7 @@ const listErrors = (results, file) => {
     .forEach(c => {
 
       console.log(chalk.white(`// --- Snippet #${c.id} in ${chalk.bold(file)} ---`))
-      c.stderr.forEach(o => console.log(chalk.red(o)))
+      console.log(chalk.red(c.stderr))
       console.log()
     })
 

--- a/run-snippet.js
+++ b/run-snippet.js
@@ -10,11 +10,11 @@ const validateSnippetResult = (code, signal, stderr) => code === 0 && !signal &&
 function runSnippet(timeout, { snippet, id }) {
   const child = exec('node')
 
-  const stdout = []
-  child.stdout.on('data', (data) => stdout.push(data))
+  let stdout = ''
+  child.stdout.on('data', (data) => stdout += data)
 
-  const stderr = []
-  child.stderr.on('data', (data) => stderr.push(data))
+  let stderr = ''
+  child.stderr.on('data', (data) => stderr += data)
 
   return new Task((reject, resolve) => {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,7 +223,7 @@ babel-register@^6.24.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -370,6 +370,12 @@ commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+common-tags@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
Also go back to using string concatenation for stdout & stderr.

@fvictorio comments 
- [stdout/stderr](https://github.com/gillchristian/snipperjs/pull/6#discussion_r109393484)
- [unnecessary wrap](https://github.com/gillchristian/snipperjs/pull/6#discussion_r109394277): this one actually gives better error logs
![image](https://cloud.githubusercontent.com/assets/8309423/24608763/510db808-184e-11e7-9204-a032d3295fd3.png)


