### PR TITLE
Exit from runner & not fail when default config file not found

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 const meow = require('meow')
+const chalk = require('chalk')
 
 const msg = `
-  Usage
-    $ chimi -f file
+  ${chalk.bold.white('Usage')}
+  $ chimi -f <file> -c <config-file>
 
-  Options
+  ${chalk.bold.white('Options')}
     --file,   -f  File or glob matching multiple files (default: "README.md")
-    --config, -c  Use configuration from this file (default: ".chimirc")
+    --config, -c  Use configuration from this file     (default: ".chimirc")
 
-  Examples
+  ${chalk.bold.white('Examples')}
     $ chimi -f README.md
 
     $ chimi -f doc/*.md

--- a/example/readme.md
+++ b/example/readme.md
@@ -56,5 +56,5 @@ This snippet will not finish running. _The default timeout is 5s_.
 ```js
 setTimeout(() => {
   console.log('I will never run')
-},10 * 1000)
+}, 10 * 1000)
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,7 @@ function getConfig(file) {
 
   const conf = fs.existsSync(f)
     ? Either.Right(readConf(isJS, fromPkg, f))
-    : Either.Left(notExistMsg(f, file))
+    : file === '.chimirc' ? Either.Right({}) : Either.Left(notExistMsg(f, file))
 
   return conf.map(R.merge(defaults))
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -87,13 +87,15 @@ const reducers = [
   (acc, cur) => (cur.timeout ? acc + 1 : acc),
 ]
 
-// countCases :: List(FileResult) -> {files: Int, success: Int, success: Int}
+// Cases ::  {files: Int, success: Int, reject: Int, timeout: Int, total: Int }
+
+// countCases :: List(FileResult) -> Cases
 const countCases = results => {
   const [success, reject, timeout] = reducers.map(reduceSnippets(results))
 
   const total = results.reduce((acc, { snippets }) => acc + snippets.size, 0)
 
-  return { files: results.size, total, success, reject, timeout }
+  return { files: results.size, success, reject, timeout, total }
 }
 
 // reportNoFilesFound :: Spinner -> (String -> ())
@@ -102,7 +104,7 @@ const reportNoFilesFound = spinner => glob => {
   console.log(chalk.bold('\n¯\\_(ツ)_/¯'))
 }
 
-// reportResults :: Spinner -> String -> ([Object] -> ())
+// reportResults :: Spinner -> String -> ([FileResult] -> Cases)
 const reportResults = (spinner, glob) => results => {
   const cases = countCases(results)
 
@@ -139,7 +141,7 @@ const reportResults = (spinner, glob) => results => {
 
   logSummary(cases)
 
-  process.exit(Boolean(cases.reject) ? 1 : 0)
+  return cases
 }
 
 module.exports = {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -10,8 +10,8 @@ function runner(dependencies, timeout, glob) {
     .map(reportResults(spinner, glob))
     .fork(
       error => spinner.fail(error.message),
-      ({ reject }) => {
-        process.exit(Boolean(reject) ? 1 : 0)
+      (results = { reject: 1 }) => {
+        process.exit(Boolean(results.reject) ? 1 : 0)
       }
     )
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,10 +6,14 @@ function runner(dependencies, timeout, glob) {
 
   spinner.start()
 
-  return taskOfSnippets(dependencies, timeout, glob).fork(
-    error => spinner.fail(error.message),
-    reportResults(spinner, glob)
-  )
+  return taskOfSnippets(dependencies, timeout, glob)
+    .map(reportResults(spinner, glob))
+    .fork(
+      error => spinner.fail(error.message),
+      ({ reject }) => {
+        process.exit(Boolean(reject) ? 1 : 0)
+      }
+    )
 }
 
 module.exports = runner


### PR DESCRIPTION
This PR adds two changes

- When default config file `.chimirc` is not found use default values
- Moves `process.exit` from `lib/reporter` to `lib/runner`

Also add colors to the CLI help text ¯\\\_(ツ)_/¯