### PR TITLE
Add cosmiconfig

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -9,11 +9,10 @@ const readConfig = require('../lib/config')
 
 const msg = `
   ${chalk.bold.white('Usage')}
-  $ chimi -f <file> -c <config-file>
+  $ chimi -f <file>
 
   ${chalk.bold.white('Options')}
     --file,    -f      File or glob matching multiple files (default: "README.md")
-    --config,  -c      Use configuration from this file     (default: ".chimirc")
     --help,    -h      Show help
     --silent           Prevent snippets from printing messages through the console
     --version, -v, -V  Show version
@@ -22,31 +21,20 @@ const msg = `
     $ chimi -f README.md
 
     $ chimi -f doc/*.md
-
-    $ chimi -c chimi.config.js
 `
 
 const cli = meow(msg, {
   alias: {
     f: 'file',
-    c: 'config',
     h: 'help',
     v: 'version',
     V: 'version',
   },
-  default: {
-    config: '.chimirc',
-  },
+  default: {},
 })
 
-const eitherConfig = readConfig(cli.flags.config)
+const config = readConfig()
 
-if (eitherConfig.isLeft) {
-  console.error(S.either(S.I, S.I, eitherConfig))
-  process.exit(1)
-}
-
-const config = S.either(S.I, S.I, eitherConfig)
 const file = cli.flags.file || config.file
 
 runner(config.dependencies, config.timeout, file, cli.flags.silent)

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,38 +2,23 @@ const fs = require('fs')
 const path = require('path')
 
 const chalk = require('chalk')
+const cosmiconfig = require('cosmiconfig')
 const R = require('ramda')
 
 // sanctuary with Fluture types added
 const S = require('./sanctuary')
 const defaults = require('./defaults')
 
-// notExistMsg :: String -> String -> String
-const notExistMsg = (p, f) =>
-  `File ${p.replace(f, chalk.bold.white(f))} does not exist`
+const explorer = cosmiconfig('chimi', {
+  sync: true,
+})
 
-// readConf :: Bool -> Bool -> String -> Object
-const readConf = (isJS, fromPkg, file) =>
-  isJS
-    ? require(file)
-    : R.compose(
-        R.when(R.always(fromPkg), R.prop('chimi')),
-        JSON.parse,
-        fs.readFileSync
-      )(file)
+// getConfig :: String -> ChimiConfig
+function getConfig() {
+  const config = S.map(S.prop('config'), S.toMaybe(explorer.load('.')))
+  const mergedConfig = S.map(R.merge(defaults), config)
 
-// getConfig :: String -> Either(String, ChimiConfig)
-function getConfig(file) {
-  const fromPkg = /package\.json$/.test(file)
-  const isJS = /js$/.test(file)
-
-  const f = path.resolve(process.cwd(), file)
-
-  const conf = fs.existsSync(f)
-    ? S.Right(readConf(isJS, fromPkg, f))
-    : file === '.chimirc' ? S.Right({}) : S.Left(notExistMsg(f, file))
-
-  return S.map(R.merge(defaults), conf)
+  return S.fromMaybe(defaults, mergedConfig)
 }
 
 module.exports = getConfig

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chalk": "^1.1.3",
     "chipa": "^0.1.1",
     "common-tags": "^1.4.0",
+    "cosmiconfig": "^3.1.0",
     "fluture": "^7.1.3",
     "fluture-sanctuary-types": "^1.3.0",
     "meow": "^3.7.0",

--- a/readme.md
+++ b/readme.md
@@ -24,11 +24,10 @@ $ npm i -g chimi
   Run JavaScript snippets from your markdown files
 
   Usage
-  $ chimi -f <file> -c <config-file>
+  $ chimi -f <file>
 
   Options
     --file,    -f      File or glob matching multiple files (default: "README.md")
-    --config,  -c      Use configuration from this file     (default: ".chimirc")
     --help,    -h      Show help
     --silent           Prevent snippets from printing messages through the console
     --version, -v, -V  Show version
@@ -37,8 +36,6 @@ $ npm i -g chimi
     $ chimi -f README.md
 
     $ chimi -f doc/*.md
-
-    $ chimi -c chimi.config.js
 ```
 
 ## Configuration
@@ -57,7 +54,7 @@ You can configure `chimi` using a configuration file, it might be a JSON or Java
 
 ```
 {
-  "dependencies": { 
+  "dependencies": {
     "trae": "trae",
     "lodash": "_",
     "./config": "config",

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,6 +657,15 @@ cosmiconfig@^1.1.0:
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
 
+cosmiconfig@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^3.0.0"
+    require-from-string "^2.0.1"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -797,7 +806,7 @@ errno@^0.1.4:
   dependencies:
     prr "~0.0.0"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -1391,6 +1400,10 @@ is-decimal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.1.tgz#f5fb6a94996ad9e8e3761fbfbd091f1fca8c4e82"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -1825,7 +1838,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2196,17 +2209,13 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
@@ -2487,6 +2496,12 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
+  dependencies:
+    error-ex "^1.3.1"
 
 parse5@^1.5.1:
   version "1.5.1"
@@ -2836,6 +2851,10 @@ require-directory@^2.1.1:
 require-from-string@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
 
 require-main-filename@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I removed the `--config` option for now, because I didn't find a way to force cosmiconfig to use a given file. The user will have to use one of the configurations supported out of the box by `cosmiconfig`, at least for now.

We need to start merging PRs btw.