### PR TITLE
Rework the dependencies config value

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+flow-typed

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 flow-typed
+coverage

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,13 @@
         "trailingComma": "es5"
       }
     ],
-    "no-console": 0
+    "no-console": "off",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   },
   "globals" : {
     "it": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "extends": [
+    "airbnb-base",
+    "prettier"
+  ],
+  "plugins": [
+    "prettier"
+  ],
+  "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true,
+        "semi": false,
+        "parser": "flow",
+        "trailingComma": "es5"
+      }
+    ],
+    "no-console": 0
+  },
+  "globals" : {
+    "it": false,
+    "expect": false,
+    "describe": false,
+    "jest": false
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,11 +23,5 @@
         "devDependencies": true
       }
     ]
-  },
-  "globals" : {
-    "it": false,
-    "expect": false,
-    "describe": false,
-    "jest": false
   }
 }

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -3,8 +3,6 @@
 const meow = require('meow')
 const chalk = require('chalk')
 
-// sanctuary with Fluture types added
-const S = require('../lib/sanctuary')
 const runner = require('../lib/runner')
 const readConfig = require('../lib/config')
 

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -21,7 +21,7 @@ const msg = `
   ${chalk.bold.white('Examples')}
     $ chimi -f README.md
 
-    $ chimi -f doc/*.md
+    $ chimi -f 'doc/*.md'
 `
 
 const cli = meow(msg, {
@@ -38,10 +38,4 @@ const config = readConfig()
 
 const file = cli.flags.file || config.file
 
-runner(
-  config.dependencies,
-  config.globals,
-  config.timeout,
-  file,
-  cli.flags.silent
-)
+runner(file, config, cli.flags)

--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.json",
+  "env": {
+    "jest": true
+  }
+}

--- a/e2e/__snapshots__/test.js.snap
+++ b/e2e/__snapshots__/test.js.snap
@@ -105,12 +105,35 @@ ReferenceError: answer is not defined
     at Function.Module._load (module.js:500:3)
     at Function.Module.runMain (module.js:665:10)
     at startup (bootstrap_node.js:187:16)
-    at bootstrap_node.js:608:3
+    at bootstrap_node.js:607:3
 
 
  FAIL  0-README.md
 
   Files: 1
   Snippets rejected: 1
+"
+`;
+
+exports[`e2e tests should run 06-with-dependencies as expected 1`] = `
+"
+Output
+
+----- README.md ----- 
+
+--- Snippet #1 ---
+I'm here for the side effects
+
+
+--- Snippet #2 ---
+I'm here for the side effects
+8080
+
+
+ PASS  0-README.md
+ PASS  1-README.md
+
+  Files: 1
+  Snippets succeded: 2
 "
 `;

--- a/e2e/fixtures/06-with-dependencies/README.md
+++ b/e2e/fixtures/06-with-dependencies/README.md
@@ -1,0 +1,8 @@
+```js
+R.is(Number, 1)
+sanctuary.is(Number, 1)
+```
+
+```js
+console.log(config.port)
+```

--- a/e2e/fixtures/06-with-dependencies/chimi.config.js
+++ b/e2e/fixtures/06-with-dependencies/chimi.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  dependencies: [
+    'sanctuary',
+    { module: './side-effects.js' },
+    { name: 'R', module: 'ramda' },
+    { name: 'config', module: './config' },
+  ],
+}

--- a/e2e/fixtures/06-with-dependencies/config.js
+++ b/e2e/fixtures/06-with-dependencies/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  port: process.env.PORT || 8080,
+}

--- a/e2e/fixtures/06-with-dependencies/expectations.json
+++ b/e2e/fixtures/06-with-dependencies/expectations.json
@@ -1,0 +1,4 @@
+{
+  "status": 0,
+  "arguments": ""
+}

--- a/e2e/fixtures/06-with-dependencies/side-effects.js
+++ b/e2e/fixtures/06-with-dependencies/side-effects.js
@@ -1,0 +1,1 @@
+console.log("I'm here for the side effects")

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 const shell = require('shelljs')
 
 const chimiBin = path.resolve(__dirname, '..', 'bin', 'bin.js')

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 const shell = require('shelljs')
 
 const chimiBin = path.resolve(__dirname, '..', 'bin', 'bin.js')
@@ -12,12 +13,14 @@ const fixturesDirs = fs
   .filter(x => fs.lstatSync(x).isDirectory())
 
 describe('e2e tests', () => {
+  // eslint-disable-next-line no-restricted-syntax,prefer-const
   for (let fixtureDir of fixturesDirs) {
     const relativeFixtureDir = path.relative(fixturesRoot, fixtureDir)
 
     it(`should run ${relativeFixtureDir} as expected`, () => {
       shell.cd(fixtureDir)
 
+      // eslint-disable-next-line global-require,import/no-dynamic-require
       const expectations = require(path.join(fixtureDir, 'expectations.json'))
       const command = `${chimiBin} ${expectations.arguments || ''}`
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "chimi": "./bin/bin.js"
   },
   "scripts": {
-    "dev": "babel --watch src -d lib",
-    "build": "babel src/ -d lib/ && yarn format",
+    "dev": "babel --watch src/ -d lib/",
+    "build": "babel src/ -d lib/ && yarn prettier --write 'lib/*.js'",
     "dev": "babel src/ -w -d lib/",
     "prettier": "prettier --no-semi --single-quote --trailing-comma es5 --parser flow",
     "format": "yarn prettier --write '**/*.js'",
@@ -15,6 +15,7 @@
     "precommit": "yarn check && yarn build && lint-staged",
     "prepublish": "yarn build",
     "release": "np",
+    "lint": "yarn eslint '**/*.js'",
     "test": "jest ./tests",
     "e2e": "jest ./e2e"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "dev": "babel --watch src/ -d lib/",
     "build": "babel src/ -d lib/ && yarn prettier --write 'lib/*.js'",
-    "dev": "babel src/ -w -d lib/",
     "prettier": "prettier --no-semi --single-quote --trailing-comma es5 --parser flow",
     "format": "yarn prettier --write '**/*.js'",
     "flow": "flow",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "babel --watch src -d lib",
     "build": "babel src/ -d lib/ && yarn format",
+    "dev": "babel src/ -w -d lib/",
     "prettier": "prettier --no-semi --single-quote --trailing-comma es5 --parser flow",
     "format": "yarn prettier --write '**/*.js'",
     "flow": "flow",
@@ -49,6 +50,11 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-flow": "^6.23.0",
+    "eslint": "^4.9.0",
+    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-config-prettier": "^2.6.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-prettier": "^2.3.1",
     "flow-bin": "^0.56.0",
     "flow-typed": "^2.2.0",
     "husky": "^0.13.3",

--- a/readme.md
+++ b/readme.md
@@ -54,12 +54,12 @@ You can configure `chimi` using a configuration file, it might be a JSON or Java
 
 ```
 {
-  "dependencies": {
-    "trae": "trae",
-    "lodash": "_",
-    "./config": "config",
-    "es6-promise: ""
-  },
+  "dependencies": [
+    "trae",
+    { "module": "lodash", "name": "_" },
+    { "module": "./config", "name": "config" },
+    { "module": "es6-promise" }
+  ],
   "globals": {
     "answer": 42,
     "add": "(a, b) => a + b",
@@ -75,22 +75,24 @@ You can configure `chimi` using a configuration file, it might be a JSON or Java
 
 **NOTE**: _if it is a JavaScript file, an object has to be exported_.
 
-`dependencies`: `object`
+### `dependencies`: `Array<string|object>`
 
-A list of dependencies to be `require`d on each snippet. Each key represents the path name and the value is the variable name, if the value is an empty string the `require` statement will be not assigned to a variable.
+A list of dependencies to be `require`d on each snippet. 
+
+Pass a string when the variable name and the module to be required are equal. To cover other cases you can pass an object with variable name as the `name` property, the module as the `module` property, if the name is missing the require will not have an assignment.
 
 The depenencies in the example will generate these `require`s:
 ```js
-let trae   = require('trae')
-let _      = require('lodash')
-let config = require('./config')
+const trae   = require('trae')
+const _      = require('lodash')
+const config = require('./config')
 
 require('es6-promise')
 ```
 
 These dependencies will be added to your snippet before running it so you don't have to do it on every snippet.
 
-`globals`: `object`
+### `globals`: `object`
 
 A list of variable declarations to add on each snippet. Each key represents the variable name and the value is, well, the value.
 
@@ -119,13 +121,13 @@ let wrong = hello world
 let right = 'hello world'
 ```
 
-`file`: `string`
+### `file`: `string`
 
 Default: `README.md`.
 
 The path to the file/s you want to parse. It can also be a [glob](https://github.com/isaacs/node-glob#glob-primer). Be sure to specify only `.md` files.
 
-`timeout`: `number`
+### `timeout`: `number`
 
 Default: `5000`.
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,3 @@
-const fs = require('fs')
-const path = require('path')
-
-const chalk = require('chalk')
 const cosmiconfig = require('cosmiconfig')
 const R = require('ramda')
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,6 @@
-// ChimiConfig :: { file: String, timeout: Int, dependencies: { String:String }, globals: { String:String } }
 module.exports = {
   file: 'README.md',
   timeout: 5 * 1000,
-  dependencies: {},
+  dependencies: [],
   globals: {},
 }

--- a/src/lib.js
+++ b/src/lib.js
@@ -28,11 +28,11 @@ const handleDep = S.ifElse(
 )
 
 // listDependencies :: [string|Object] -> String
-const listDependencies = R.compose(
+const listDependencies = S.pipe([
+  S.map(handleDep),
+  S.map(appendSemi),
   S.joinWith('\n'),
-  R.map(appendSemi),
-  R.map(handleDep)
-)
+])
 
 // listGlobals :: Object -> String
 const listGlobals = globals =>

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,5 +1,3 @@
-const fs = require('fs')
-
 const R = require('ramda')
 const Future = require('fluture')
 const { extract } = require('chipa')
@@ -7,37 +5,40 @@ const { SourceMapGenerator } = require('source-map')
 
 // sanctuary with Fluture types added
 const S = require('./sanctuary')
-const { readFile, taskify } = require('./utils')
+const { taskify } = require('./utils')
 const runSnippets = require('./run-snippet')
 
+const appendSemi = r => `${r};`
+
 // requireWithAssignment :: String -> String -> String
-const requireWithAssignment = (path, name) => `let ${name} = require('${path}')`
+const requireWithAssignment = (name, module, type = 'const') =>
+  `${type} ${name} = require('${module || name}')`
 
 // simpleRequire :: String -> String
-const simpleRequire = path => `require('${path}')`
+const simpleRequire = module => `require('${module}')`
 
-// buildRequireExpression :: String -> String -> String
-const buildRequireExpression = R.ifElse(
-  (_, value) => Boolean(value),
+// assignmentExpression :: String -> String -> String
+const assignmentExpression = (key, value) => `let ${key} = ${value}`
+
+const handleDep = S.ifElse(
+  S.is(String),
   requireWithAssignment,
-  simpleRequire
+  ({ name, module, type }) =>
+    name ? requireWithAssignment(name, module, type) : simpleRequire(module)
 )
 
-// buildAssignementExpression :: String -> String -> String
-const buildAssignementExpression = (key, value) => `let ${key} = ${value}`
-
-// listDependencies :: Object -> String
-const listDependencies = deps =>
-  Object.keys(deps)
-    .map(key => buildRequireExpression(key, deps[key]))
-    .map(r => r + ';')
-    .join('\n')
+// listDependencies :: [string|Object] -> String
+const listDependencies = R.compose(
+  S.joinWith('\n'),
+  R.map(appendSemi),
+  R.map(handleDep)
+)
 
 // listGlobals :: Object -> String
 const listGlobals = globals =>
   Object.keys(globals)
-    .map(key => buildAssignementExpression(key, globals[key]))
-    .map(r => r + ';')
+    .map(key => assignmentExpression(key, globals[key]))
+    .map(appendSemi)
     .join('\n')
 
 const generateSourceMaps = (code, dependencies, globals) => {
@@ -55,6 +56,7 @@ const generateSourceMaps = (code, dependencies, globals) => {
     file: '/decorated-snippet.js',
   })
 
+  // eslint-disable-next-line no-plusplus
   for (let i = 0; i < codeLinesCount; i++) {
     map.addMapping({
       generated: {
@@ -76,10 +78,10 @@ const generateSourceMaps = (code, dependencies, globals) => {
 
 // injectDependencies :: Object -> Object -> String -> String
 const injectDependencies = (deps, globals, code) => {
-  const dependencies = listDependencies(deps || {})
+  const dependencies = listDependencies(deps || [])
   const globalsStr = listGlobals(globals || {})
   const sourceMaps = generateSourceMaps(code, dependencies, globalsStr)
-  const sourceMapsBase64 = new Buffer(sourceMaps).toString('base64')
+  const sourceMapsBase64 = Buffer.from(sourceMaps).toString('base64')
 
   const sourceMapsInline = `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${sourceMapsBase64}`
 
@@ -139,7 +141,7 @@ const skip = S.map(R.evolve({ snippets: S.filter(matchNoSkip) }))
 // @link: https://github.com/isaacs/node-glob#glob-primer
 
 // taskOfSnippets :: Object -> Object -> Int -> GlobPattern -> Future([FileResult])
-const taskOfSnippets = (dependencies, globals, timeout, glob) =>
+const taskOfSnippets = ({ dependencies, globals, timeout }, glob) =>
   S.pipe(
     [
       S.map(skip),
@@ -151,5 +153,6 @@ const taskOfSnippets = (dependencies, globals, timeout, glob) =>
 
 module.exports = {
   injectDependencies,
+  listDependencies,
   taskOfSnippets,
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -41,7 +41,7 @@ const listOutput = results => {
 
     snippets
       .filter(R.compose(Boolean, R.path(['stdout', 'length'])))
-      .forEach((c, i) => {
+      .forEach(c => {
         console.log(chalk.white(`--- Snippet #${c.id + 1} ---`))
         console.log(chalk.white(c.stdout))
         console.log()
@@ -50,13 +50,13 @@ const listOutput = results => {
 }
 
 // listErrors :: [Object] -> ()
-const listErrors = (results, file) => {
+const listErrors = results => {
   console.log(chalk.bold.red(`\nErrors\n`))
 
   results.forEach(({ file, snippets }) => {
     console.log(chalk.bold.white(`----- ${file} ----- \n`))
 
-    snippets.filter(R.compose(R.not, R.prop('ok'))).forEach((c, i) => {
+    snippets.filter(R.compose(R.not, R.prop('ok'))).forEach(c => {
       console.log(chalk.white(`--- Snippet #${c.id + 1} ---`))
       if (c.timeout) {
         const err = new Error(`Snippet #${c.id + 1} from ${file} timed out.`)
@@ -70,9 +70,9 @@ const listErrors = (results, file) => {
 }
 
 // reduceSnippets :: [Result] -> (Int -> Snippet) -> Int
-const _reduceSnippets = (rs, f) =>
+const reduceSnippets = R.curry((rs, f) =>
   rs.reduce((acc, { snippets }) => acc + snippets.reduce(f, 0), 0)
-const reduceSnippets = R.curry(_reduceSnippets)
+)
 
 const reducers = [
   // success: counts the s.ok === true cases
@@ -139,6 +139,7 @@ const reportResults = (spinner, glob, silent) => results => {
 
   logSummary(cases)
 
+  // eslint-disable-next-line consistent-return
   return cases
 }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,17 +1,19 @@
+const Future = require('fluture')
+
 const { taskOfSnippets } = require('./lib')
 const { createSpinner, reportResults } = require('./reporter')
 
-function runner(dependencies, globals, timeout, glob, silent) {
+function runner(glob, config, { silent }) {
   const spinner = createSpinner()
 
   spinner.start()
 
-  return taskOfSnippets(dependencies, globals, timeout, glob)
-    .map(reportResults(spinner, glob, silent))
+  return taskOfSnippets(config, glob)
+    .chain(Future.encase(reportResults(spinner, glob, silent)))
     .fork(
       error => spinner.fail(error.message),
       (results = { reject: 1 }) => {
-        process.exit(Boolean(results.reject) ? 1 : 0)
+        process.exit(results.reject ? 1 : 0)
       }
     )
 }

--- a/src/sanctuary.js
+++ b/src/sanctuary.js
@@ -1,9 +1,30 @@
+const R = require('ramda')
 const { create, env } = require('sanctuary')
+const { NullaryType } = require('sanctuary-def')
 const flutureEnv = require('fluture-sanctuary-types').env
+
+const isString = R.is(String)
+const isObject = R.is(Object)
+
+const propIsString = prop => R.compose(isString, R.prop(prop))
+const optionalPropIsString = prop =>
+  R.ifElse(R.has(prop), propIsString(prop), R.T)
+
+const checkProps = R.allPass([
+  propIsString('module'),
+  optionalPropIsString('name'),
+  optionalPropIsString('type'),
+])
+
+const isDepObject = R.both(isObject, checkProps)
+
+const isDep = R.either(isString, isDepObject)
+
+const chimiDependency = NullaryType('chimi/Dependency', '#', isDep)
 
 const S = create({
   checkTypes: true,
-  env: env.concat(flutureEnv),
+  env: env.concat(flutureEnv, [chimiDependency]),
 })
 
 module.exports = S

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.json",
+  "env": {
+    "jest": true
+  }
+}

--- a/tests/__snapshots__/lib.spec.js.snap
+++ b/tests/__snapshots__/lib.spec.js.snap
@@ -15,14 +15,38 @@ console.log(answer)
 exports[`lib injectDependencies should add globals and dependencies 1`] = `
 "require('source-map-support').install()
 // snippet dependencies
-let _ = require('lodash');
+const _ = require('lodash');
+let theAnswer = 42;
 
-require('theAnswer');
+const answer = 42
+
+console.log(answer)
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7O0FBQUE7QUFDQTtBQUNBIiwiZmlsZSI6Ii9kZWNvcmF0ZWQtc25pcHBldC5qcyIsInNvdXJjZXNDb250ZW50IjpbImNvbnN0IGFuc3dlciA9IDQyXG5cbmNvbnNvbGUubG9nKGFuc3dlcikiXX0="
+`;
+
+exports[`lib injectDependencies should add requires with no declaration when the name is missing 1`] = `
+"require('source-map-support').install()
+// snippet dependencies
+require('./for-the-side-effects');
+require('es6-promise');
+
 
 const answer = 42
 
 console.log(answer)
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQSIsImZpbGUiOiIvZGVjb3JhdGVkLXNuaXBwZXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBhbnN3ZXIgPSA0MlxuXG5jb25zb2xlLmxvZyhhbnN3ZXIpIl19"
+`;
+
+exports[`lib injectDependencies should add source maps but no dependencies 1`] = `
+"require('source-map-support').install()
+// snippet dependencies
+
+
+
+const answer = 42
+
+console.log(answer)
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7O0FBQUE7QUFDQTtBQUNBIiwiZmlsZSI6Ii9kZWNvcmF0ZWQtc25pcHBldC5qcyIsInNvdXJjZXNDb250ZW50IjpbImNvbnN0IGFuc3dlciA9IDQyXG5cbmNvbnNvbGUubG9nKGFuc3dlcikiXX0="
 `;
 
 exports[`lib injectDependencies should interpolate functions, arrays, objets and strings properly 1`] = `
@@ -38,20 +62,6 @@ const answer = 42
 
 console.log(answer)
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7O0FBQUE7QUFDQTtBQUNBIiwiZmlsZSI6Ii9kZWNvcmF0ZWQtc25pcHBldC5qcyIsInNvdXJjZXNDb250ZW50IjpbImNvbnN0IGFuc3dlciA9IDQyXG5cbmNvbnNvbGUubG9nKGFuc3dlcikiXX0="
-`;
-
-exports[`lib injectDependencies should not add a variable declaration when dependencies map values are falsy 1`] = `
-"require('source-map-support').install()
-// snippet dependencies
-let false = require('./for-the-side-effects');
-let false = require('es6-promise');
-
-
-
-const answer = 42
-
-console.log(answer)
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7QUFBQTtBQUNBO0FBQ0EiLCJmaWxlIjoiL2RlY29yYXRlZC1zbmlwcGV0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiY29uc3QgYW5zd2VyID0gNDJcblxuY29uc29sZS5sb2coYW5zd2VyKSJdfQ=="
 `;
 
 exports[`lib injectDependencies should not change snippet indentation 1`] = `
@@ -91,19 +101,7 @@ Promise.resolve(foo)
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQSIsImZpbGUiOiIvZGVjb3JhdGVkLXNuaXBwZXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBmb28gPSB7XG4gIGJhcjogXCJiYXJcIlxufTtcblxuUHJvbWlzZS5yZXNvbHZlKGZvbylcbiAgLnRoZW4oKHsgYmFyIH0pID0+IGJhcilcbiAgLnRoZW4oYmFyID0+IHtcbiAgICBjb25zb2xlLmxvZyhiYXIpO1xuICB9KTsiXX0="
 `;
 
-exports[`lib injectDependencies should only add the source maps code when no dependencies are passed 1`] = `
-"require('source-map-support').install()
-// snippet dependencies
-
-
-
-const answer = 42
-
-console.log(answer)
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7O0FBQUE7QUFDQTtBQUNBIiwiZmlsZSI6Ii9kZWNvcmF0ZWQtc25pcHBldC5qcyIsInNvdXJjZXNDb250ZW50IjpbImNvbnN0IGFuc3dlciA9IDQyXG5cbmNvbnNvbGUubG9nKGFuc3dlcikiXX0="
-`;
-
-exports[`lib injectDependencies should prepend requires with variable declarations to the input 1`] = `
+exports[`lib injectDependencies should prepend requires with variable declarations to the snippet code 1`] = `
 "require('source-map-support').install()
 // snippet dependencies
 const _ = require('lodash');
@@ -115,18 +113,17 @@ console.log(answer)
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7O0FBQUE7QUFDQTtBQUNBIiwiZmlsZSI6Ii9kZWNvcmF0ZWQtc25pcHBldC5qcyIsInNvdXJjZXNDb250ZW50IjpbImNvbnN0IGFuc3dlciA9IDQyXG5cbmNvbnNvbGUubG9nKGFuc3dlcikiXX0="
 `;
 
-exports[`lib injectDependencies should prepend requires with variable declarations to the input 2`] = `
+exports[`lib injectDependencies should prepend requires with variable declarations to the snippet code 2`] = `
 "require('source-map-support').install()
 // snippet dependencies
-let _ = require('lodash');
-let trae = require('trae');
-
+const _ = require('lodash');
+const trae = require('trae');
 
 
 const answer = 42
 
 console.log(answer)
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7QUFBQTtBQUNBO0FBQ0EiLCJmaWxlIjoiL2RlY29yYXRlZC1zbmlwcGV0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiY29uc3QgYW5zd2VyID0gNDJcblxuY29uc29sZS5sb2coYW5zd2VyKSJdfQ=="
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQSIsImZpbGUiOiIvZGVjb3JhdGVkLXNuaXBwZXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBhbnN3ZXIgPSA0MlxuXG5jb25zb2xlLmxvZyhhbnN3ZXIpIl19"
 `;
 
 exports[`lib injectDependencies should work for local dependencies 1`] = `

--- a/tests/__snapshots__/lib.spec.js.snap
+++ b/tests/__snapshots__/lib.spec.js.snap
@@ -16,12 +16,13 @@ exports[`lib injectDependencies should add globals and dependencies 1`] = `
 "require('source-map-support').install()
 // snippet dependencies
 let _ = require('lodash');
-let theAnswer = 42;
+
+require('theAnswer');
 
 const answer = 42
 
 console.log(answer)
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7O0FBQUE7QUFDQTtBQUNBIiwiZmlsZSI6Ii9kZWNvcmF0ZWQtc25pcHBldC5qcyIsInNvdXJjZXNDb250ZW50IjpbImNvbnN0IGFuc3dlciA9IDQyXG5cbmNvbnNvbGUubG9nKGFuc3dlcikiXX0="
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQSIsImZpbGUiOiIvZGVjb3JhdGVkLXNuaXBwZXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBhbnN3ZXIgPSA0MlxuXG5jb25zb2xlLmxvZyhhbnN3ZXIpIl19"
 `;
 
 exports[`lib injectDependencies should interpolate functions, arrays, objets and strings properly 1`] = `
@@ -42,14 +43,15 @@ console.log(answer)
 exports[`lib injectDependencies should not add a variable declaration when dependencies map values are falsy 1`] = `
 "require('source-map-support').install()
 // snippet dependencies
-require('./for-the-side-effects');
-require('es6-promise');
+let false = require('./for-the-side-effects');
+let false = require('es6-promise');
+
 
 
 const answer = 42
 
 console.log(answer)
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQSIsImZpbGUiOiIvZGVjb3JhdGVkLXNuaXBwZXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBhbnN3ZXIgPSA0MlxuXG5jb25zb2xlLmxvZyhhbnN3ZXIpIl19"
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7QUFBQTtBQUNBO0FBQ0EiLCJmaWxlIjoiL2RlY29yYXRlZC1zbmlwcGV0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiY29uc3QgYW5zd2VyID0gNDJcblxuY29uc29sZS5sb2coYW5zd2VyKSJdfQ=="
 `;
 
 exports[`lib injectDependencies should not change snippet indentation 1`] = `
@@ -73,8 +75,8 @@ Promise.resolve(foo)
 exports[`lib injectDependencies should not change snippet indentation 2`] = `
 "require('source-map-support').install()
 // snippet dependencies
-let _ = require('lodash');
-let lib = require('./lib');
+const _ = require('lodash');
+const lib = require('./lib');
 
 
 const foo = {
@@ -104,7 +106,7 @@ console.log(answer)
 exports[`lib injectDependencies should prepend requires with variable declarations to the input 1`] = `
 "require('source-map-support').install()
 // snippet dependencies
-let _ = require('lodash');
+const _ = require('lodash');
 
 
 const answer = 42
@@ -120,21 +122,29 @@ let _ = require('lodash');
 let trae = require('trae');
 
 
+
+const answer = 42
+
+console.log(answer)
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7QUFBQTtBQUNBO0FBQ0EiLCJmaWxlIjoiL2RlY29yYXRlZC1zbmlwcGV0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiY29uc3QgYW5zd2VyID0gNDJcblxuY29uc29sZS5sb2coYW5zd2VyKSJdfQ=="
+`;
+
+exports[`lib injectDependencies should work for local dependencies 1`] = `
+"require('source-map-support').install()
+// snippet dependencies
+const lib = require('./lib');
+const bar = require('../foo/bar');
+
+
 const answer = 42
 
 console.log(answer)
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQSIsImZpbGUiOiIvZGVjb3JhdGVkLXNuaXBwZXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBhbnN3ZXIgPSA0MlxuXG5jb25zb2xlLmxvZyhhbnN3ZXIpIl19"
 `;
 
-exports[`lib injectDependencies should work for local dependencies 1`] = `
-"require('source-map-support').install()
-// snippet dependencies
-let lib = require('./lib');
-let bar = require('../foo/bar');
-
-
-const answer = 42
-
-console.log(answer)
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zbmlwcGV0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQSIsImZpbGUiOiIvZGVjb3JhdGVkLXNuaXBwZXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBhbnN3ZXIgPSA0MlxuXG5jb25zb2xlLmxvZyhhbnN3ZXIpIl19"
+exports[`lib listDependencies should list dependencies in different types 1`] = `
+"const trae = require('trae');
+require('es6-promise');
+const _ = require('lodash');
+let config = require('./config');"
 `;

--- a/tests/lib.spec.js
+++ b/tests/lib.spec.js
@@ -22,7 +22,7 @@ describe('lib', () => {
       console.log(answer)
     `
 
-    it('should only add the source maps code when no dependencies are passed', () => {
+    it('should add source maps but no dependencies', () => {
       const result = injectDependencies([], {}, code)
 
       expect(result).toMatchSnapshot()
@@ -59,7 +59,7 @@ describe('lib', () => {
       expect(result).toMatchSnapshot()
     })
 
-    it('should prepend requires with variable declarations to the input', () => {
+    it('should prepend requires with variable declarations to the snippet code', () => {
       let dependencies = [
         {
           name: '_',
@@ -77,7 +77,7 @@ describe('lib', () => {
         },
         'trae',
       ]
-      result = injectDependencies(dependencies, {}, [], code)
+      result = injectDependencies(dependencies, {}, code)
 
       expect(result).toMatchSnapshot()
     })
@@ -98,7 +98,7 @@ describe('lib', () => {
       expect(result).toMatchSnapshot()
     })
 
-    it('should not add a variable declaration when dependencies map values are falsy', () => {
+    it('should add requires with no declaration when the name is missing', () => {
       const dependencies = [
         {
           module: './for-the-side-effects',
@@ -107,7 +107,7 @@ describe('lib', () => {
           module: 'es6-promise',
         },
       ]
-      const result = injectDependencies(dependencies, {}, [], code)
+      const result = injectDependencies(dependencies, {}, code)
 
       expect(result).toMatchSnapshot()
     })
@@ -122,9 +122,12 @@ describe('lib', () => {
     })
 
     it('should add globals and dependencies', () => {
-      const dependencies = {
-        lodash: '_',
-      }
+      const dependencies = [
+        {
+          name: '_',
+          module: 'lodash',
+        },
+      ]
       const globals = {
         theAnswer: 42,
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,23 @@ acorn-globals@^3.1.0:
   dependencies:
     acorn "^4.0.4"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
 acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
+
+acorn@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
 ajv-keywords@^2.1.0:
   version "2.1.0"
@@ -39,6 +53,15 @@ ajv@^5.1.0, ajv@^5.2.3:
     fast-deep-equal "^1.0.0"
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -229,7 +252,7 @@ babel-cli@^6.26.0:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -490,9 +513,19 @@ buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -611,6 +644,10 @@ ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
 
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -708,6 +745,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+concat-stream@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 concurrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/concurrify/-/concurrify-1.0.1.tgz#1febe4b4615d4a86ee293a39713ffad5feb9681e"
@@ -729,6 +774,10 @@ configstore@^3.0.0:
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
 content-type-parser@^1.0.1:
   version "1.0.1"
@@ -774,7 +823,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -834,6 +883,12 @@ debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -858,7 +913,7 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
-del@^2.2.0:
+del@^2.0.2, del@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
   dependencies:
@@ -891,6 +946,20 @@ detect-indent@^4.0.0:
 diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
 
 dot-prop@^4.1.0:
   version "4.2.0"
@@ -939,6 +1008,114 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.5.6"
 
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
+
+eslint-config-prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz#f21db0ebb438ad678fb98946097c4bb198befccc"
+  dependencies:
+    get-stdin "^5.0.1"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"
+  dependencies:
+    debug "^2.6.8"
+    resolve "^1.2.0"
+
+eslint-module-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+
+eslint-plugin-prettier@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz#e7a746c67e716f335274b88295a9ead9f544e44d"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.9.0.tgz#76879d274068261b191fe0f2f56c74c2f4208e8b"
+  dependencies:
+    ajv "^5.2.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.0.1"
+    doctrine "^2.0.0"
+    eslint-scope "^3.7.1"
+    espree "^3.5.1"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^9.17.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "^4.0.1"
+    text-table "~0.2.0"
+
+espree@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
+  dependencies:
+    acorn "^5.1.1"
+    acorn-jsx "^3.0.0"
+
 esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
@@ -947,7 +1124,20 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-estraverse@^4.2.0:
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
+  dependencies:
+    estraverse "^4.1.0"
+    object-assign "^4.0.1"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -1038,6 +1228,14 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
+fast-diff@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -1060,6 +1258,13 @@ figures@^2.0.0:
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -1098,6 +1303,15 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 flow-bin@^0.56.0:
   version "0.56.0"
@@ -1223,6 +1437,10 @@ function-bind@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1243,6 +1461,10 @@ get-caller-file@^1.0.1:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1290,7 +1512,7 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-globals@^9.18.0:
+globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -1500,6 +1722,10 @@ iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
+ignore@^3.3.3:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.6.tgz#b6f3196b38ed92f0c86e52f6f79b7fc4c8266c8d"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -1525,7 +1751,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1730,6 +1956,12 @@ is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
 
+is-resolvable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
+  dependencies:
+    tryit "^1.0.1"
+
 is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
@@ -1758,7 +1990,7 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -1911,7 +2143,7 @@ jest-diff@^21.2.1:
     jest-get-type "^21.2.0"
     pretty-format "^21.2.1"
 
-jest-docblock@^21.2.0:
+jest-docblock@^21.0.0, jest-docblock@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
@@ -2075,7 +2307,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2191,7 +2423,7 @@ leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -2312,6 +2544,10 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6:
 lodash.chunk@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
 lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
@@ -2666,7 +2902,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -2823,7 +3059,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
@@ -2875,9 +3111,19 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
 pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2909,6 +3155,10 @@ private@^0.1.7:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -2989,7 +3239,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -3199,9 +3449,26 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
 resolve@1.1.7, resolve@^1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -3630,6 +3897,10 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -3690,6 +3961,10 @@ trough@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
 
+tryit@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -3705,6 +3980,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 uglify-js@^2.6:
   version "2.8.29"
@@ -3961,6 +4240,12 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.1.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 x-is-function@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This PR changes the way dependencies are handled.

```js
// from this
[
  'trae',
  { module: 'ramda', name: 'R' },
  { module: './config', name: 'config', type: 'let' },
  { module: 'es6-promise' }
]

// to this
const trae = require('trae')
const R    = require('ramda')
let config = require('./config')
require('es6-promise')
```

Also added `eslint` since `prettier` only takes care of the formatting.