### PR TITLE
Encase catchable functions

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -144,8 +144,8 @@ const skip = S.map(R.evolve({ snippets: S.filter(matchNoSkip) }))
 const taskOfSnippets = ({ dependencies, globals, timeout }, glob) =>
   S.pipe(
     [
-      S.map(skip),
-      S.map(normalizeFiles(dependencies, globals)),
+      S.chain(Future.encase(skip)),
+      S.chain(Future.encase(normalizeFiles(dependencies, globals))),
       S.chain(traverseFiles(timeout)),
     ],
     taskify(extract)(glob, ['js', 'javascript'])


### PR DESCRIPTION
This should fix or improve the situation with #15. Not the more DRY solution, but at least the spinner doesn't hangs forever when there is a problem.