### PR TITLE
Fix paths in snapshots & improve docs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 80,
+  "semi": false,
+  "trailingComma": "es5",
+  "parser": "flow"
+}

--- a/e2e/__snapshots__/test.js.snap
+++ b/e2e/__snapshots__/test.js.snap
@@ -93,7 +93,7 @@ Errors
 
 --- Snippet #1 ---
 ReferenceError: answer is not defined
-    at Object.<anonymous> (/README.md:4:1)
+    at Object.<anonymous> (<PROJECT_ROOT>/e2e/fixtures/05-simple-fail/README.md:6:13)
     at Module._compile (module.js:624:30)
     at Object.Module._extensions..js (module.js:635:10)
     at Module.load (module.js:545:32)
@@ -106,7 +106,7 @@ ReferenceError: answer is not defined
 
 --- Snippet #2 ---
 ReferenceError: answer is not defined
-    at Object.<anonymous> (/README.md:14:1)
+    at Object.<anonymous> (<PROJECT_ROOT>/e2e/fixtures/05-simple-fail/README.md:10:22)
     at Module._compile (module.js:624:30)
     at Object.Module._extensions..js (module.js:635:10)
     at Module.load (module.js:545:32)

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -6,8 +6,6 @@ const shell = require('shelljs')
 const chimiBin = path.resolve(__dirname, '..', 'bin', 'bin.js')
 const fixturesRoot = path.join(__dirname, 'fixtures')
 
-process.env.NODE_ENV = 'dev'
-
 const fixturesDirs = fs
   .readdirSync(fixturesRoot)
   .map(x => path.join(fixturesRoot, x))

--- a/flow-typed/npm/ramda_v0.x.x.js
+++ b/flow-typed/npm/ramda_v0.x.x.js
@@ -330,16 +330,16 @@ declare module ramda {
   }
 
   /**
-  * DONE:
-  * Function*
-  * List*
-  * Logic
-  * Math
-  * Object*
-  * Relation
-  * String
-  * Type
-  */
+   * DONE:
+   * Function*
+   * List*
+   * Logic
+   * Math
+   * Object*
+   * Relation
+   * String
+   * Type
+   */
 
   declare var compose: Compose
   declare var pipe: Pipe

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  snapshotSerializers: ['jest-serializer-path'],
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "dev": "babel --watch src/ -d lib/",
     "build": "babel src/ -d lib/ && yarn prettier --write 'lib/*.js'",
-    "prettier": "prettier --no-semi --single-quote --trailing-comma es5 --parser flow",
     "format": "yarn prettier --write '**/*.js'",
+    "format:docs": "yarn prettier --parser markdown --write '**/*.md'",
     "flow": "flow",
     "precommit": "yarn check && yarn build && lint-staged",
     "prepublish": "yarn build",
@@ -61,9 +61,10 @@
     "flow-typed": "^2.2.0",
     "husky": "^0.13.3",
     "jest": "^21.2.1",
+    "jest-serializer-path": "^0.1.3",
     "lint-staged": "^3.4.1",
     "np": "^2.14.1",
-    "prettier": "^1.7.4",
+    "prettier": "^1.8.2",
     "shelljs": "^0.7.8"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chimi",
   "version": "0.2.0",
-  "description": "Validate JavaScript code from your README",
+  "description": "Validate the JavaScript code of your Markdown files",
   "bin": {
     "chimi": "./bin/bin.js"
   },
@@ -9,7 +9,6 @@
     "dev": "babel --watch src/ -d lib/",
     "build": "babel src/ -d lib/ && yarn prettier --write 'lib/*.js'",
     "format": "yarn prettier --write '**/*.js'",
-    "format:docs": "yarn prettier --parser markdown --write '**/*.md'",
     "flow": "flow",
     "precommit": "yarn check && yarn build && lint-staged",
     "prepublish": "yarn build",

--- a/readme.md
+++ b/readme.md
@@ -6,30 +6,44 @@
 
 ## Table of contents
 
-1. [How it works](#how-it-works)
+1. [The problem](#the-problem)
+1. [This solution](#this-solution)
+1. [Installation](#installation)
 1. [Usage](#usage)
 1. [Configuration](#configuration)
+1. [Inspiration](#inspiration)
+1. [Similar and complementary tools](#similar-and-complementary-tools)
 
-## How it works
+## The problem
 
-`chimi` parses Markdown files and runs the JavaScript snippets to check if everything is alright.
+> A great OpenSource project is only as great as its documentation.
+>
+> _Probably me_.
+
+We ~~ideally~~ test our code and care about it's quality, but not so much about documentation. Snippets of code in the docs sometimes have typos or even are out of sync with the library version.
+
+## This solution
+
+`chimi` aims to bring the same principles we use for automating tests of our code to test the documentation. By parsing Markdown files and runnings the JavaScript snippets to check if everything is alright.
 
 ## Installation
 
 ```bash
 $ yarn add chimi --dev
 $ npm i chimi --save-dev
+```
 
-# global works too
+Global works too
 
+```bash
 $ yarn global add chimi
 $ npm i -g chimi
 ```
 
-# Usage
+## Usage
 
 ```
-  Run JavaScript snippets from your markdown files
+  Validate the JavaScript code of your Markdown files
 
   Usage
   $ chimi -f <file>
@@ -43,7 +57,7 @@ $ npm i -g chimi
   Examples
     $ chimi -f README.md
 
-    $ chimi -f doc/*.md
+    $ chimi -f 'doc/*.md'
 ```
 
 ## Configuration
@@ -58,9 +72,9 @@ To let `chimi` find the snippets you have to indicate the snippet language using
 ```javascript
 ```
 
-You can configure `chimi` using a configuration file, it might be a JSON or JavaScript file and also an object as the `chimi` property in the `package.json`:
+You can configure `chimi` using a configuration file, it might be a JSON or JavaScript file (`chimi.config.js`, `.chimirc`) and also an object as the `chimi` property in the `package.json`:
 
-```
+```js
 {
   "dependencies": [
     "trae",
@@ -73,23 +87,28 @@ You can configure `chimi` using a configuration file, it might be a JSON or Java
     "add": "(a, b) => a + b",
     "message": "'hello world'",
     "fruits": "['orange', 'apple']",
-    "config": "{ port: 8080 }",
+    "config": "{ port: 8080 }"
+  },
+  "globals": {
+    "./dist/my-lib": "my-lib"
   },
   "file": "readme.md",
   "timeout": 5000
 }
 ```
+
 **NOTE**: _the `.chimirc` file has to be a valid JSON_.
 
 **NOTE**: _if it is a JavaScript file, an object has to be exported_.
 
 ### `dependencies`: `Array<string|object>`
 
-A list of dependencies to be `require`d on each snippet. 
+A list of dependencies to be `require`d on each snippet.
 
 Pass a string when the variable name and the module to be required are equal. To cover other cases you can pass an object with variable name as the `name` property, the module as the `module` property, if the name is missing the require will not have an assignment.
 
 The depenencies in the example will generate these `require`s:
+
 ```js
 const trae   = require('trae')
 const _      = require('lodash')
@@ -98,13 +117,14 @@ const config = require('./config')
 require('es6-promise')
 ```
 
-These dependencies will be added to your snippet before running it so you don't have to do it on every snippet.
+These dependencies will be added to your snippet before running it so you don't have to do it on every snippet. You can use it to implicitly refer to your project or to do some setup for the snippets (i.e. mock an http request).
 
 ### `globals`: `object`
 
 A list of variable declarations to add on each snippet. Each key represents the variable name and the value is, well, the value.
 
 The globals in the example will generate these declarations:
+
 ```js
 let answer  = 42
 let add     = (a, b) => a + b
@@ -129,6 +149,26 @@ let wrong = hello world
 let right = 'hello world'
 ```
 
+### `alias`: `object`
+
+An object containing aliases for imports and requires, with the format `{ [path to replace]: alias }`.
+
+The `alias` in the example will transform following snippet:
+
+```js
+import myLib from 'my-lib'
+
+const lib = require('my-lib')
+```
+
+to this before running it.
+
+```js
+import myLib from './dist/my-lib'
+
+const lib = require('./dist/my-lib')
+```
+
 ### `file`: `string`
 
 Default: `README.md`.
@@ -149,8 +189,24 @@ Chimi supports the following annotations:
 
 #### Skip
 
-To skip a snippet:
+To skip a snippet from running:
 
 ```
 ```js (skip)
 ```
+
+This is useful when the snippet has purposely incompleted or broken code.
+
+## Inspiration
+
+`chimi` was inspired on [budziq](https://github.com/budziq)'s [rust-skeptic](https://github.com/budziq/rust-skeptic), a similar tool for Rust, by [franleplant](https://github.com/franleplant) suggestion:
+
+> _would be cool to have it [rust-skeptic] for JS_.
+
+## Similar and complementary tools
+
+There are other tools that will help you improve your JS in Markdown.
+
+- [`prettier`](https://prettier.io/): Formas JavaScript, Markdown and other languages. Since `v1.8` it supports [formatting Markdown files its JS snippets](https://github.com/prettier/prettier/releases/tag/1.8.0).
+
+- [`eslint-plugin-markdown`](https://github.com/eslint/eslint-plugin-markdown): Lints JavaScript code blocks in Markdown documents. Since `chimi` runs the code, there are things `eslint` could miss, e.g. you added a breaking change to the library but forgot to update your docs. But if you only want to lint your code, then `eslint-plugin-markdown` is all you need.

--- a/src/transformers/inject-dependencies.js
+++ b/src/transformers/inject-dependencies.js
@@ -9,7 +9,6 @@ const generateSourceMaps = (
   dependencies,
   globals
 ) => {
-  const source = process.env.NODE_ENV === 'dev' ? `/${file}` : file
   const decoratedCodeFirstLine =
     1 +
     1 + // require source-map-suppor
@@ -35,11 +34,11 @@ const generateSourceMaps = (
         line: position.start.line + i + 1,
         column: 0,
       },
-      source,
+      source: file,
     })
   }
 
-  map.setSourceContent(source, code)
+  map.setSourceContent(file, code)
 
   return map.toJSON()
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,6 +2258,10 @@ jest-runtime@^21.2.1:
     write-file-atomic "^2.1.0"
     yargs "^9.0.0"
 
+jest-serializer-path@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/jest-serializer-path/-/jest-serializer-path-0.1.3.tgz#022bd32dc2a47c4cf7905dad5e2bf6bc85e4d125"
+
 jest-snapshot@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
@@ -3130,9 +3134,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
+prettier@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
 
 pretty-format@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
This PR 

- Adds `jest-serializer-path` to remove absolute paths from Jest snapshots. #44 
- Updates `prettier` version & scripts
- Updates the `readme.md` #43 